### PR TITLE
Fix unit-test project path destination

### DIFF
--- a/NativeLibs.CppParser.sln
+++ b/NativeLibs.CppParser.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NativeLibs.CppParser", "src\NativeLibs.CppParser.csproj", "{4F6D36C2-DBFC-4BA1-A285-F8E5D065F39C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NativeLibs.CppParser.Tests", "tests\NativeLibs.CppParser.Tests\NativeLibs.CppParser.Tests.csproj", "{3C293338-B2A8-474D-8BEC-F4C2FD3DCA1F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NativeLibs.CppParser.Tests", "tests\NativeLibs.CppParser.Tests.csproj", "{3C293338-B2A8-474D-8BEC-F4C2FD3DCA1F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tests/NativeLibs.CppParser.Tests.csproj
+++ b/tests/NativeLibs.CppParser.Tests.csproj
@@ -17,7 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\src\NativeLibs.CppParser.csproj" />
+		<ProjectReference Include="..\src\NativeLibs.CppParser.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Unit-test project had `./tests/NativeLibs.CppParser.Tests/NativeLibs.CppParser.Tests.csproj` path, so on GitHub we saw two folders (`src` and `tests/NativeLibs.CppParser.Tests`). I removed folder for unit-test project to make it look good. Now we'll have two short folders ☺️